### PR TITLE
Added restriction to use copy and move assign operator

### DIFF
--- a/CppPractice/lowsrc/MemoryPool/MemoryPool.hpp
+++ b/CppPractice/lowsrc/MemoryPool/MemoryPool.hpp
@@ -47,6 +47,38 @@ public:
     MemoryPool(const MemoryPool& other) = delete;
     MemoryPool(MemoryPool&& other) noexcept = delete;
 
+    MemoryPool& operator=(const MemoryPool& other) = delete;
+    MemoryPool& operator=(MemoryPool&& other) noexcept = delete;
+
+    /**
+     * @return Allocated size
+     */
+    int GetSize()
+    {
+        return size_;
+    }
+    
+    // Releases resources - Whole memory block will no longer be managed by MemoryPool 
+    T* Release()
+    {
+        T* tmp = mem_pool_;
+
+        Reset();
+
+        return tmp;
+    }
+
+    // Frees all allocated resources
+    void Reset()
+    {
+        free(mem_pool_);
+        free(mem_alloc_);
+        
+        mem_pool_  = nullptr;
+        mem_alloc_ = nullptr;
+        size_ = 0;
+    }
+
     T* AllocateMemory() noexcept
     {
         for (size_t i = 0; i < size_; i++)


### PR DESCRIPTION
Implemented GetSize() function to retrieve currently allocated size 
Implemented Release() - Releases resources - MemoryPool will no longer be responsible for released memory block 
Implemented Reset() frees and resets pointers + allocated size indicator